### PR TITLE
Power instead of Mana

### DIFF
--- a/definitions/SpellPower.dbd
+++ b/definitions/SpellPower.dbd
@@ -13,9 +13,9 @@ int Field_752352413?
 float Field_3042231609?
 int ID
 int AltPowerBarID
-int ManaCost
-int ManaCostPerLevel
-int ManaPerSecond
+int PowerCost
+int PowerCostPerLevel
+int PowerPerSecond
 int OptionalCost
 int OrderIndex
 float PowerCostMaxPct
@@ -45,7 +45,7 @@ LAYOUT 8E5E46EC
 BUILD 8.0.1.25902, 8.0.1.25976, 8.0.1.26010, 8.0.1.26032, 8.0.1.26095, 8.0.1.26131, 8.0.1.26141, 8.0.1.26175, 8.0.1.26231
 BUILD 7.3.5.25928, 7.3.5.25937, 7.3.5.25944, 7.3.5.25946, 7.3.5.25950, 7.3.5.25961, 7.3.5.25996, 7.3.5.26124, 7.3.5.26365, 7.3.5.26654, 7.3.5.26755, 7.3.5.26822, 7.3.5.26899, 7.3.5.26972
 BUILD 1.13.0.28211
-ManaCost<32>
+PowerCost<32>
 PowerCostPct
 PowerPctPerSecond
 RequiredAuraSpellID<32>
@@ -53,8 +53,8 @@ PowerCostMaxPct
 OrderIndex<u8>
 PowerType<8>
 $id$ID<32>
-ManaCostPerLevel<32>
-ManaPerSecond<32>
+PowerCostPerLevel<32>
+PowerPerSecond<32>
 OptionalCost<u32>
 PowerDisplayID<u32>
 AltPowerBarID<32>
@@ -62,7 +62,7 @@ $noninline,relation$SpellID<32>
 
 LAYOUT F3C96414
 BUILD 8.0.1.26287, 8.0.1.26297, 8.0.1.26310, 8.0.1.26321, 8.0.1.26367, 8.0.1.26433, 8.0.1.26476, 8.0.1.26491, 8.0.1.26522, 8.0.1.26530, 8.0.1.26557, 8.0.1.26567, 8.0.1.26585, 8.0.1.26604, 8.0.1.26610, 8.0.1.26624, 8.0.1.26629, 8.0.1.26637, 8.0.1.26640, 8.0.1.26683, 8.0.1.26707, 8.0.1.26714, 8.0.1.26715, 8.0.1.26734, 8.0.1.26766
-ManaCost<32>
+PowerCost<32>
 PowerCostPct
 PowerCostMaxPct
 PowerPctPerSecond
@@ -70,8 +70,8 @@ RequiredAuraSpellID<32>
 OrderIndex<u8>
 PowerType<8>
 $id$ID<32>
-ManaCostPerLevel<32>
-ManaPerSecond<32>
+PowerCostPerLevel<32>
+PowerPerSecond<32>
 PowerDisplayID<u32>
 AltPowerBarID<32>
 OptionalCost<u32>
@@ -91,9 +91,9 @@ BUILD 1.13.3.32790, 1.13.3.32836, 1.13.3.32887, 1.13.3.33155, 1.13.3.33302, 1.13
 BUILD 1.13.2.30073, 1.13.2.30112, 1.13.2.30113, 1.13.2.30128, 1.13.2.30172, 1.13.2.30232, 1.13.2.30265, 1.13.2.30287, 1.13.2.30406, 1.13.2.30550, 1.13.2.30682, 1.13.2.30786, 1.13.2.30862, 1.13.2.30901, 1.13.2.30979, 1.13.2.31043, 1.13.2.31118, 1.13.2.31209, 1.13.2.31402, 1.13.2.31407, 1.13.2.31446, 1.13.2.31650, 1.13.2.31687, 1.13.2.31727, 1.13.2.31830, 1.13.2.31882, 1.13.2.32089, 1.13.2.32421, 1.13.2.32600
 $id$ID<32>
 OrderIndex<u8>
-ManaCost<32>
-ManaCostPerLevel<32>
-ManaPerSecond<32>
+PowerCost<32>
+PowerCostPerLevel<32>
+PowerPerSecond<32>
 PowerDisplayID<u32>
 AltPowerBarID<32>
 PowerCostPct


### PR DESCRIPTION
Replaced Mana occurrences into Power, as it doesn't only represent Mana but also other kind of powers.